### PR TITLE
Fix DaemonSet spec

### DIFF
--- a/manifests/eks-nvme-ssd-provisioner.yaml
+++ b/manifests/eks-nvme-ssd-provisioner.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app: eks-nvme-ssd-provisioner
 spec:
+  selector:
+    matchLabels:
+      name: eks-nvme-ssd-provisioner
   template:
     metadata:
       labels:


### PR DESCRIPTION
Example DaemonSet spec was missing a required `selector`, which is required
as of Kubernetes 1.8 (which is quite old now). See
https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector
for details.