### PR TITLE
Add soft link to make a persistent volume available for hostPath mount

### DIFF
--- a/eks-nvme-ssd-provisioner.sh
+++ b/eks-nvme-ssd-provisioner.sh
@@ -49,6 +49,7 @@ esac
 UUID=$(blkid -s UUID -o value $DEVICE)
 mkdir -p /pv-disks/$UUID
 mount -o defaults,noatime,discard,nobarrier --uuid $UUID /pv-disks/$UUID
+ln -s /pv-disks/$UUID /nvme/disk
 echo "Device $DEVICE has been mounted to /pv-disks/$UUID"
 echo "NVMe SSD provisioning is done and I will go to sleep now"
 

--- a/eks-nvme-ssd-provisioner.sh
+++ b/eks-nvme-ssd-provisioner.sh
@@ -49,6 +49,7 @@ esac
 UUID=$(blkid -s UUID -o value $DEVICE)
 mkdir -p /pv-disks/$UUID
 mount -o defaults,noatime,discard,nobarrier --uuid $UUID /pv-disks/$UUID
+ln -s /pv-disks/$UUID /nvme
 echo "Device $DEVICE has been mounted to /pv-disks/$UUID"
 echo "NVMe SSD provisioning is done and I will go to sleep now"
 

--- a/manifests/eks-nvme-ssd-provisioner.yaml
+++ b/manifests/eks-nvme-ssd-provisioner.yaml
@@ -28,7 +28,13 @@ spec:
           - mountPath: /pv-disks
             name: pv-disks
             mountPropagation: "Bidirectional"
+          - mountPath: /nvme
+            name: nvme
+            mountPropagation: "Bidirectional"
       volumes:
       - name: pv-disks
         hostPath:
           path: /pv-disks
+      - name: nvme
+        hostPath:
+          path: /nvme


### PR DESCRIPTION
Hi, Jonas. We at Protofire are using this solution in our EKS cluster. We've found that it is a bit hard to use this when it comes to Spot instances as the PVC are not getting recreated with the Node. As such, we decided to use `hostPath` volume instead of PVC. It would be great if we could keep using this repo instead of forking to the new one. It would require only one small fix to make it work with hostPath and it will be completely backward compatible, so if it is possible I would absolutely love to have this fix on the upstream. Thanks! 