### PR TITLE
Upgraded to Alpine 3.14

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,13 @@
-FROM alpine:3.8
+FROM alpine:3.14
 
-RUN apk add --update-cache mdadm nvme-cli bash e2fsprogs blkid util-linux
+RUN \
+  apk update update && apk add --no-cache \
+    bash \
+    blkid \
+    e2fsprogs \
+    mdadm \
+    nvme-cli \
+    util-linux
 COPY eks-nvme-ssd-provisioner.sh /usr/local/bin/
 
 ENTRYPOINT ["eks-nvme-ssd-provisioner.sh"]


### PR DESCRIPTION
- Upgraded the Alpine base image to 3.14 . Now it only has one false positive  `medium` level CVE: [CVE-2010-3262](https://nvd.nist.gov/vuln/detail/CVE-2010-3262)  .
- Removed the cache of the `.apk` files to make a smaller image (now it is 18.2MB)
- Tidied up a bit the package list to make it more readable, naturally sorted, etc.