### PR TITLE
apply affinity to DS template

### DIFF
--- a/helm/eks-nvme-ssd-provisioner/templates/daemonset.yaml
+++ b/helm/eks-nvme-ssd-provisioner/templates/daemonset.yaml
@@ -13,6 +13,10 @@ spec:
       labels:
         {{- include "eks-nvme-ssd-provisioner.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
In your helm chart you define a value `affinity`. But in your `DaemonSet` template you're not applying it. 

